### PR TITLE
Bump Carbon's version to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "source": "https://github.com/gbuckingham89/youtube-rss-parser"
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1.8",
         "guzzlehttp/guzzle": "^6.2",
-        "nesbot/carbon": "^1.22"
+        "nesbot/carbon": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is because Carbon V1 is being deprecated. 
- No changes are required for this package's use cases.
- We had to bump PHP to 7.1.8 for compatibility with Carbon v2.